### PR TITLE
"Fixed" Everything Update check

### DIFF
--- a/update-rules.json
+++ b/update-rules.json
@@ -392,11 +392,11 @@
     "updater": {
       "x86": {
         "rule_type": "css-link",
-        "selector": "a[href$='x86.Multilingual-Setup.exe']"
+        "selector": "a[href$='x86-Setup.exe']"
       },
       "x86_64": {
         "rule_type": "css-link",
-        "selector": "a[href$='x64.Multilingual-Setup.exe']"
+        "selector": "a[href$='x64-Setup.exe']"
       }
     },
     "version_extractor": "([.\\d]+[.]\\d{1,5})"


### PR DESCRIPTION
The "multilingual" part of the multilingual files are removed in the new Everything version (1.4.1) so i removed that. Hopefully this fixes the Everything version that's stuck on 1.3.4.