### PR TITLE
feat(config): add mono

### DIFF
--- a/update-rules.json
+++ b/update-rules.json
@@ -739,6 +739,17 @@
     },
     "version_extractor": "mercurial-([0-9]*(?:\\.[0-9]+)*)-[a-z0-9]{3}\\.msi$"
   },
+  "mono": {
+    "url": "http://www.mono-project.com/download/",
+    "updater": {
+      "x86": {
+        "rule_type": "css-link",
+        "selector": "a[href*='download.mono-project.com'][href$='.msi']",
+        "filter": "^((?!x64).)*$"
+      }
+    },
+    "version_extractor": "mono-([0-9]*(?:\\.[0-9]+)*)-"
+  },
   "mpc-hc": {
     "url": "https://mpc-hc.org/downloads/",
     "updater": {


### PR DESCRIPTION
since on the mono download page there is also a xamarin download-link (which is also a .msi), i added "download.mono-project.com" as an extra selector.

currently no x64 download since it has no full scope atm (no integrated gtk#).